### PR TITLE
Test: demo build error in GitOps workflow

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -5,7 +5,9 @@ import { CheckSquare, FlaskConical, Info } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { ModeToggle } from "./mode-toggle";
+
+// Temporarily commented out to simulate a build error demo
+// import { ModeToggle } from "./mode-toggle";
 
 export function Navbar() {
     const pathname = usePathname();

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -6,8 +6,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
-// Temporarily commented out to simulate a build error demo
-// import { ModeToggle } from "./mode-toggle";
+import { ModeToggle } from "./mode-toggle";
 
 export function Navbar() {
     const pathname = usePathname();


### PR DESCRIPTION
### What
This PR intentionally comments out a required import (`ModeToggle`) to simulate a build error during the GitOps pipeline.

### Why
To demonstrate how the GitOps CI/CD pipeline handles failed builds, and to show the notification/rollback mechanism.

### Notes
- Do not merge this PR into production.
- For demo purposes only.
